### PR TITLE
fix: 後台Menu手機桌面共用一個children、新增Tutor和Student的menu

### DIFF
--- a/src/components/layout/BackendPanelMenu.jsx
+++ b/src/components/layout/BackendPanelMenu.jsx
@@ -39,15 +39,21 @@ const Link = styled(NavLink)`
   color: ${(props) => (props.type === "student" ? "var(--bs-gray-03)" : "var(--bs-gray-03)")};
 
   .icon-fill {
-    margin-right: 4px;
+    margin-right: 8px;
   }
 `;
 
-const RightContentWrapper = styled.div`
+const MainContentWrapper = styled.div`
   flex-grow: 1;
   padding: 36px;
   overflow-y: auto;
   height: 100vh;
+
+  @media (max-width: 992px) {
+    padding: 0;
+    margin-top: 24px;
+    height: 100%;
+  }
 `;
 
 export default function BackendPanelMenu({ children, type, menuItems, user }) {
@@ -58,99 +64,100 @@ export default function BackendPanelMenu({ children, type, menuItems, user }) {
     setIsMenuOpen((prev) => !prev);
   };
 
-  if (isMobile) {
-    return (
-      <>
-        {isMenuOpen && <style>{`body { overflow: hidden; }`}</style>}
-        <nav className={`layout-nav-wrap navbar navbar-expand-lg ${type === "student" ? "bg-white" : "bg-gray-01"}`}>
-          <div className="container-lg">
-            <div className="d-flex">
-              <NavLink to="/" className="navbar-brand me-10">
-                <picture>
-                  <source srcSet="images/logo-sm.svg" media="(max-width: 575.98px)" />
-                  <img src="images/logo.svg" alt="logo-image" />
-                </picture>
-              </NavLink>
-            </div>
-            <button
-              id="layout-navbar-toggler"
-              className="navbar-toggler border-0 p-2"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#navbarSupportedContent"
-              aria-controls="navbarSupportedContent"
-              aria-expanded="false"
-              aria-label="Toggle navigation"
-              onClick={handleTogglerClick}
-            >
-              <span id="menu-icon" className={`material-symbols-outlined icon-fill fs-4 ${type === "student" ? "text-gray-01" : "text-white"} ${isMenuOpen && "d-none"}`}>
-                menu
-              </span>
-              <span id="close-icon" className={`material-symbols-outlined icon-fill fs-4 ${type === "student" ? "text-gray-01" : "text-white"} ${isMenuOpen ? "" : "d-none"}`}>
-                close
-              </span>
-            </button>
-            <div id="navbarSupportedContent" className={`collapse navbar-collapse justify-content-end ${isMenuOpen && "show"} ${type === "student" ? "bg-white" : "bg-gray-01"}`}>
-              <ul className="navbar-nav align-items-lg-center">
-                {menuItems.map((item) => (
-                  <ListItem key={item.name} type={type} className={location.pathname === item.href ? "active" : ""}>
-                    <Link to={item.href}>
-                      <span className="material-symbols-outlined icon-fill">{item.icon}</span>
-                      <span>{item.name}</span>
-                    </Link>
-                  </ListItem>
-                ))}
-                <li className="nav-item nav-bottom-btn">
-                  <div className="d-flex align-items-center">
-                    <div className="flex-shrink-0">
-                      <img src={user.avatar} alt="profile" className="object-fit-cover rounded-circle me-4" style={{ height: "48px", width: "48px" }} />
-                    </div>
-                    <div className="flex-grow-1">
-                      <p className={clsx("fs-6", { "text-gray-01": type === "student", "text-white": type === "tutor" })}>{user.name}</p>
-                    </div>
-                  </div>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </nav>
-        <div className="mt-6">{children}</div>
-      </>
-    );
-  }
-
   return (
-    <div className="d-flex">
-      <Container type={type}>
-        <NavLink className="navbar-brand mb-8" to="/">
-          <picture>
-            <source srcSet="images/logo-sm.svg" media="(max-width: 575.98px)" />
-            <img src="images/logo.svg" alt="logo-image" />
-          </picture>
-        </NavLink>
-        <ul>
-          {menuItems.map((item) => (
-            <ListItem key={item.name} type={type} className={location.pathname === item.href ? "active" : ""}>
-              <Link to={item.href}>
-                <span className="material-symbols-outlined icon-fill">{item.icon}</span>
-                <span>{item.name}</span>
-              </Link>
-            </ListItem>
-          ))}
-        </ul>
-        <div className="d-flex align-items-center mt-auto">
-          <div className="flex-shrink-0">
-            <img src={user.avatar} alt="profile" className="object-fit-cover rounded-circle me-4" style={{ height: "48px", width: "48px" }} />
-          </div>
-          <div className="flex-grow-1">
-            <p className={clsx("fs-6", { "text-gray-01": type === "student", "text-white": type === "tutor" })}>{user.name}</p>
-          </div>
-        </div>
-      </Container>
+    <>
+      <div className={`${isMobile ? "" : "d-flex"}`}>
+        {isMobile ? (
+          // Mobile Menu
+          <>
+            {isMenuOpen && <style>{`body { overflow: hidden; }`}</style>}
+            <nav className={`layout-nav-wrap navbar navbar-expand-lg ${type === "student" ? "bg-white" : "bg-gray-01"}`}>
+              <div className="container-lg">
+                <div className="d-flex">
+                  <NavLink to="/" className="navbar-brand me-10">
+                    <picture>
+                      <source srcSet="images/logo-sm.svg" media="(max-width: 575.98px)" />
+                      <img src="images/logo.svg" alt="logo-image" />
+                    </picture>
+                  </NavLink>
+                </div>
+                <button
+                  id="layout-navbar-toggler"
+                  className="navbar-toggler border-0 p-2"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#navbarSupportedContent"
+                  aria-controls="navbarSupportedContent"
+                  aria-expanded="false"
+                  aria-label="Toggle navigation"
+                  onClick={handleTogglerClick}
+                >
+                  <span id="menu-icon" className={`material-symbols-outlined icon-fill fs-4 ${type === "student" ? "text-gray-01" : "text-white"} ${isMenuOpen && "d-none"}`}>
+                    menu
+                  </span>
+                  <span id="close-icon" className={`material-symbols-outlined icon-fill fs-4 ${type === "student" ? "text-gray-01" : "text-white"} ${isMenuOpen ? "" : "d-none"}`}>
+                    close
+                  </span>
+                </button>
+                <div id="navbarSupportedContent" className={`collapse navbar-collapse justify-content-end ${isMenuOpen && "show"} ${type === "student" ? "bg-white" : "bg-gray-01"}`}>
+                  <ul className="navbar-nav align-items-lg-center">
+                    {menuItems.map((item) => (
+                      <ListItem key={item.name} type={type} className={location.pathname === item.href ? "active" : ""}>
+                        <Link to={item.href}>
+                          <span className="material-symbols-outlined icon-fill">{item.icon}</span>
+                          <span>{item.name}</span>
+                        </Link>
+                      </ListItem>
+                    ))}
+                    <li className="nav-item nav-bottom-btn">
+                      <div className="d-flex align-items-center">
+                        <div className="flex-shrink-0">
+                          <img src={user.avatar} alt="profile" className="object-fit-cover rounded-circle me-4" style={{ height: "48px", width: "48px" }} />
+                        </div>
+                        <div className="flex-grow-1">
+                          <p className={clsx("fs-6", { "text-gray-01": type === "student", "text-white": type === "tutor" })}>{user.name}</p>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </nav>
+          </>
+        ) : (
+          // Desktop Menu
+          <Container type={type}>
+            <NavLink className="navbar-brand mb-8" to="/">
+              <picture>
+                <source srcSet="images/logo-sm.svg" media="(max-width: 575.98px)" />
+                <img src="images/logo.svg" alt="logo-image" />
+              </picture>
+            </NavLink>
+            <ul>
+              {menuItems.map((item) => (
+                <ListItem key={item.name} type={type} className={location.pathname === item.href ? "active" : ""}>
+                  <Link to={item.href}>
+                    <span className="material-symbols-outlined icon-fill">{item.icon}</span>
+                    <span>{item.name}</span>
+                  </Link>
+                </ListItem>
+              ))}
+            </ul>
+            <div className="d-flex align-items-center mt-auto">
+              <div className="flex-shrink-0">
+                <img src={user.avatar} alt="profile" className="object-fit-cover rounded-circle me-4" style={{ height: "48px", width: "48px" }} />
+              </div>
+              <div className="flex-grow-1">
+                <p className={clsx("fs-6", { "text-gray-01": type === "student", "text-white": type === "tutor" })}>{user.name}</p>
+              </div>
+            </div>
+          </Container>
+        )}
 
-      {/* Right content with scrollable area */}
-      <RightContentWrapper>{children}</RightContentWrapper>
-    </div>
+        {/* Shared Main Content */}
+        <MainContentWrapper>{children}</MainContentWrapper>
+      </div>
+    </>
   );
 }
 

--- a/src/components/layout/StudentPanelMenu.jsx
+++ b/src/components/layout/StudentPanelMenu.jsx
@@ -1,0 +1,57 @@
+import PropTypes from "prop-types";
+import BackendPanelMenu from "../../components/layout/BackendPanelMenu";
+
+export default function StudentPanelMenu({ children }) {
+  return (
+    <BackendPanelMenu menuItems={menuItems} type="student" user={user}>
+      {children}
+    </BackendPanelMenu>
+  );
+}
+
+const menuItems = [
+  {
+    icon: "dashboard",
+    name: "儀表板",
+    href: "/student-panel/dashboard",
+  },
+  {
+    icon: "event",
+    name: "我的預約",
+    href: "/student-panel/booking",
+  },
+  {
+    icon: "auto_stories",
+    name: "學習需求管理",
+    href: "/student-panel/learning",
+  },
+  {
+    icon: "equalizer",
+    name: "數據與趨勢",
+    href: "/student-panel/statistics",
+  },
+  {
+    icon: "notifications_active",
+    name: "個人化通知",
+    href: "/student-panel/notification",
+  },
+  {
+    icon: "person",
+    name: "個人資料管理",
+    href: "/student-panel/profile",
+  },
+  {
+    icon: "paid",
+    name: "財務管理",
+    href: "/student-panel/finance",
+  },
+];
+
+const user = {
+  avatar: "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  name: "卡斯伯Casper",
+};
+
+StudentPanelMenu.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/layout/TutorPanelMenu.jsx
+++ b/src/components/layout/TutorPanelMenu.jsx
@@ -1,0 +1,62 @@
+import PropTypes from "prop-types";
+import BackendPanelMenu from "../../components/layout/BackendPanelMenu";
+
+export default function TutorPanelMenu({ children }) {
+  return (
+    <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      {children}
+    </BackendPanelMenu>
+  );
+}
+
+const menuItems = [
+  {
+    icon: "dashboard",
+    name: "儀表板",
+    href: "/tutor-panel/dashboard",
+  },
+  {
+    icon: "video_settings",
+    name: "課程影片管理",
+    href: "/tutor-panel/course",
+  },
+  {
+    icon: "event",
+    name: "預約管理",
+    href: "/tutor-panel/booking",
+  },
+  {
+    icon: "auto_stories",
+    name: "學習需求管理",
+    href: "/tutor-panel/learning",
+  },
+  {
+    icon: "equalizer",
+    name: "數據與趨勢",
+    href: "/tutor-panel/statistics",
+  },
+  {
+    icon: "notifications_active",
+    name: "個人化通知",
+    href: "/tutor-panel/notification",
+  },
+  {
+    icon: "person",
+    name: "個人資料管理",
+    href: "/tutor-panel/profile",
+  },
+  {
+    icon: "paid",
+    name: "財務管理",
+    href: "/tutor-panel/finance",
+  },
+];
+
+const user = {
+  avatar: "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  name: "卡斯伯Casper",
+};
+
+TutorPanelMenu.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/pages/tutor/bookings/tutor-manage-bookings.jsx
+++ b/src/pages/tutor/bookings/tutor-manage-bookings.jsx
@@ -1,13 +1,9 @@
-import { useState, useEffect, useRef } from "react";
-import { useParams, useNavigate, NavLink } from "react-router-dom";
+import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 
-import axios from "axios";
-import * as bootstrap from "bootstrap";
-
-import Loader from "../../components/common/Loader";
-import BackendPanelMenu from "../../components/layout/BackendPanelMenu";
-import AllBookings from "../../components/tutor-panel/AllBookings";
+import Loader from "../../../components/common/Loader";
+import TutorPanelMenu from "../../../components/layout/TutorPanelMenu";
+import AllBookings from "../../../components/tutor-panel/AllBookings";
 
 const { VITE_API_BASE, VITE_API_BASE_2 } = import.meta.env;
 
@@ -37,7 +33,7 @@ export default function TutorManageBooking() {
         <title>Coding∞bit ｜ 講師預約管理</title>
       </Helmet>
       {loadingState && <Loader />}
-      <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      <TutorPanelMenu>
         <div className="overflow-y-auto">
           <h2 className="mb-6 ps-5 ps-lg-0">預約管理</h2>
           <ul className="nav nav-tabs">
@@ -56,50 +52,7 @@ export default function TutorManageBooking() {
 
           <div className="bg-gray-04 p-8 rounded-bottom-3 min-vh-100">{activeTab === "allBookings" && <AllBookings />}</div>
         </div>
-      </BackendPanelMenu>
+      </TutorPanelMenu>
     </>
   );
 }
-
-const menuItems = [
-  {
-    icon: "video_settings",
-    name: "課程影片管理",
-    href: "/tutor-panel/course",
-  },
-  {
-    icon: "event",
-    name: "預約管理",
-    href: "/tutor-panel/booking",
-  },
-  {
-    icon: "auto_stories",
-    name: "學習需求管理",
-    href: "/tutor-panel/learning",
-  },
-  {
-    icon: "equalizer",
-    name: "數據與趨勢",
-    href: "/tutor-panel/statistics",
-  },
-  {
-    icon: "notifications_active",
-    name: "個人化通知",
-    href: "/tutor-panel/notification",
-  },
-  {
-    icon: "person",
-    name: "個人資料管理",
-    href: "/tutor-panel/profile",
-  },
-  {
-    icon: "paid",
-    name: "財務管理",
-    href: "/tutor-panel/finance",
-  },
-];
-
-const user = {
-  avatar: "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  name: "卡斯伯Casper",
-};

--- a/src/pages/tutor/courses/tutor-addCourses-topicSeries.jsx
+++ b/src/pages/tutor/courses/tutor-addCourses-topicSeries.jsx
@@ -4,56 +4,12 @@ import { useNavigate, NavLink, Link } from "react-router-dom";
 
 import ReactQuill from "react-quill-new";
 
-import BackendPanelMenu from "../../../components/layout/BackendPanelMenu";
+import TutorPanelMenu from "../../../components/layout/TutorPanelMenu";
 import Loader from "../../../components/common/Loader";
 
 export default function TutorManageAddTopicSeries() {
   // loading
   const [loadingState, setLoadingState] = useState(false);
-
-  const menuItems = [
-    {
-      icon: "video_settings",
-      name: "課程影片管理",
-      href: "/tutor-panel/course",
-    },
-    {
-      icon: "event",
-      name: "預約管理",
-      href: "/tutor-panel/booking",
-    },
-    {
-      icon: "auto_stories",
-      name: "學習需求管理",
-      href: "/tutor-panel/learning",
-    },
-    {
-      icon: "equalizer",
-      name: "數據與趨勢",
-      href: "/tutor-panel/statistics",
-    },
-    {
-      icon: "notifications_active",
-      name: "個人化通知",
-      href: "/tutor-panel/notification",
-    },
-    {
-      icon: "person",
-      name: "個人資料管理",
-      href: "/tutor-panel/profile",
-    },
-    {
-      icon: "paid",
-      name: "財務管理",
-      href: "/tutor-panel/finance",
-    },
-  ];
-
-  const user = {
-    avatar:
-      "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    name: "卡斯伯Casper",
-  };
 
   // 返回上一頁
   const navigate = useNavigate();
@@ -64,15 +20,7 @@ export default function TutorManageAddTopicSeries() {
   // ReactQuill 文字編輯器
   const [value, setValue] = useState("");
   const modules = {
-    toolbar: [
-      [{ font: [] }],
-      ["bold", "italic", "underline"],
-      ["link", "image", "video"],
-      [{ list: "ordered" }, { list: "bullet" }],
-      [{ align: [] }],
-      ["blockquote", "code-block"],
-      ["clean"],
-    ],
+    toolbar: [[{ font: [] }], ["bold", "italic", "underline"], ["link", "image", "video"], [{ list: "ordered" }, { list: "bullet" }], [{ align: [] }], ["blockquote", "code-block"], ["clean"]],
   };
 
   return (
@@ -82,7 +30,7 @@ export default function TutorManageAddTopicSeries() {
       </Helmet>
       {loadingState && <Loader />}
 
-      <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      <TutorPanelMenu>
         <main className="tutor-add-TopicSeriesCourses-wrap container-fluid">
           <h1 className="fs-4 fs-lg-2">新增主題式課程影片 - 課程基本資料</h1>
 
@@ -92,35 +40,16 @@ export default function TutorManageAddTopicSeries() {
                 <form className="mt-6 mt-lg-8">
                   <h4 className="fs-7 fw-normal text-gray-01 lh-base">圖片</h4>
                   <div className="image-upload-wrapper mt-1">
-                    <input
-                      type="file"
-                      accept=".jpg,.jpeg,.png"
-                      className="form-control p-0"
-                      id="image"
-                    />
-                    <label
-                      htmlFor="image"
-                      className="form-label image-upload-label mb-0"
-                    >
-                      <span className="material-symbols-outlined mb-2">
-                        imagesmode
-                      </span>
+                    <input type="file" accept=".jpg,.jpeg,.png" className="form-control p-0" id="image" />
+                    <label htmlFor="image" className="form-label image-upload-label mb-0">
+                      <span className="material-symbols-outlined mb-2">imagesmode</span>
                       上傳課程封面圖片
                     </label>
 
                     {/* 上傳圖片後的樣子 */}
-                    <button
-                      type="button"
-                      className="img-wrapper border-0 p-0 d-none"
-                    >
-                      <img
-                        src="images/course/course-4.png"
-                        alt="course-thumbnail"
-                        className="w-100 object-fit"
-                      />
-                      <span className="material-symbols-outlined delete-icon">
-                        delete
-                      </span>
+                    <button type="button" className="img-wrapper border-0 p-0 d-none">
+                      <img src="images/course/course-4.png" alt="course-thumbnail" className="w-100 object-fit" />
+                      <span className="material-symbols-outlined delete-icon">delete</span>
                     </button>
                   </div>
 
@@ -128,12 +57,7 @@ export default function TutorManageAddTopicSeries() {
                     <label htmlFor="title" className="form-label">
                       系列課程標題
                     </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="title"
-                      placeholder="ex. React 進階開發技巧"
-                    />
+                    <input type="text" className="form-control" id="title" placeholder="ex. React 進階開發技巧" />
                   </div>
 
                   <div className="mt-6 mt-lg-8">
@@ -141,16 +65,9 @@ export default function TutorManageAddTopicSeries() {
                       <div className="col">
                         <label className="form-label">瀏覽權限</label>
                         <div className="dropdown">
-                          <button
-                            type="button"
-                            className="btn btn-outline-gray-03 border-1 dropdown-toggle d-block w-100 text-start px-4"
-                            data-bs-toggle="dropdown"
-                            aria-expanded="false"
-                          >
+                          <button type="button" className="btn btn-outline-gray-03 border-1 dropdown-toggle d-block w-100 text-start px-4" data-bs-toggle="dropdown" aria-expanded="false">
                             請選擇瀏覽權限
-                            <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                              keyboard_arrow_down
-                            </span>
+                            <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
                           </button>
                           <ul className="dropdown-menu w-100 mt-1">
                             <li>
@@ -179,9 +96,7 @@ export default function TutorManageAddTopicSeries() {
                             aria-expanded="false"
                           >
                             請選擇類別
-                            <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                              keyboard_arrow_down
-                            </span>
+                            <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
                           </button>
                           <ul className="dropdown-menu w-100 mt-1">
                             <li>
@@ -219,24 +134,14 @@ export default function TutorManageAddTopicSeries() {
                     <label htmlFor="searchKeywords" className="form-label">
                       關鍵字 (請用半型逗號隔開)
                     </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="searchKeywords"
-                      placeholder="ex. React, 前端開發, 效能優化, Hooks"
-                    />
+                    <input type="text" className="form-control" id="searchKeywords" placeholder="ex. React, 前端開發, 效能優化, Hooks" />
                   </div>
 
                   <div className="pb-8 mt-6 mt-lg-8">
                     <label htmlFor="content" className="form-label">
                       課程描述
                     </label>
-                    <ReactQuill
-                      value={value}
-                      onChange={setValue}
-                      placeholder="請描述課程目標、課程大綱等內容，幫助學習者快速了解。"
-                      modules={modules}
-                    />
+                    <ReactQuill value={value} onChange={setValue} placeholder="請描述課程目標、課程大綱等內容，幫助學習者快速了解。" modules={modules} />
                   </div>
                 </form>
               </div>
@@ -250,50 +155,29 @@ export default function TutorManageAddTopicSeries() {
                   <li className="f-between-center bg-brand-02 p-4">
                     <p>課程介紹</p>
                     <div className="f-align-center">
-                      <img
-                        src="images/course/course-4.png"
-                        alt="course-image"
-                      />
+                      <img src="images/course/course-4.png" alt="course-image" />
                       <p className="ms-4">React Hooks 深入解析</p>
                     </div>
                     <div className="pe-3 ps-10">
-                      <NavLink
-                        to=""
-                        className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0"
-                      >
-                        <span className="material-symbols-outlined me-1">
-                          edit
-                        </span>
+                      <NavLink to="" className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0">
+                        <span className="material-symbols-outlined me-1">edit</span>
                         編輯
                       </NavLink>
-                      <button
-                        type="button"
-                        className="btn link-danger border-0 f-align-center p-0 mt-1"
-                      >
-                        <span className="material-symbols-outlined me-1">
-                          delete
-                        </span>
+                      <button type="button" className="btn link-danger border-0 f-align-center p-0 mt-1">
+                        <span className="material-symbols-outlined me-1">delete</span>
                         刪除
                       </button>
                     </div>
                   </li>
                   <li className="f-align-center dashed-border p-4 mt-2">
                     <p>第一章</p>
-                    <Link
-                      to="/tutor-panel/course/video/topicSeries/add"
-                      className="btn btn-brand-03 f-align-center rounded-2 border-2 px-3 py-2 ms-auto"
-                    >
-                      <span className="material-symbols-outlined me-1">
-                        add
-                      </span>
+                    <Link to="/tutor-panel/course/video/topicSeries/add" className="btn btn-brand-03 f-align-center rounded-2 border-2 px-3 py-2 ms-auto">
+                      <span className="material-symbols-outlined me-1">add</span>
                       新增章節影片
                     </Link>
                   </li>
                 </ul>
-                <button
-                  type="button"
-                  className="btn btn-outline-brand-03 f-align-center rounded-2 border-2 px-3 py-2 mt-4"
-                >
+                <button type="button" className="btn btn-outline-brand-03 f-align-center rounded-2 border-2 px-3 py-2 mt-4">
                   <span className="material-symbols-outlined me-1">add</span>
                   增加新章節
                 </button>
@@ -303,12 +187,7 @@ export default function TutorManageAddTopicSeries() {
 
           {/*web button wrap */}
           <div className="btn-container text-end mt-auto">
-            <button
-              type="submit"
-              className="btn btn-outline-brand-03 rounded-2 border-3"
-              style={{ padding: "9px 24px" }}
-              onClick={toPrevPage}
-            >
+            <button type="submit" className="btn btn-outline-brand-03 rounded-2 border-3" style={{ padding: "9px 24px" }} onClick={toPrevPage}>
               取消
             </button>
             <button type="submit" className="btn btn-brand-03 rounded-2 ms-4">
@@ -316,7 +195,7 @@ export default function TutorManageAddTopicSeries() {
             </button>
           </div>
         </main>
-      </BackendPanelMenu>
+      </TutorPanelMenu>
     </>
   );
 }

--- a/src/pages/tutor/courses/tutor-addVideo.jsx
+++ b/src/pages/tutor/courses/tutor-addVideo.jsx
@@ -4,56 +4,12 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import ReactQuill from "react-quill-new";
 
-import BackendPanelMenu from "../../../components/layout/BackendPanelMenu";
+import TutorPanelMenu from "../../../components/layout/TutorPanelMenu";
 import Loader from "../../../components/common/Loader";
 
 export default function TutorManageAddVideo() {
   // loading
   const [loadingState, setLoadingState] = useState(false);
-
-  const menuItems = [
-    {
-      icon: "video_settings",
-      name: "課程影片管理",
-      href: "/tutor-panel/course",
-    },
-    {
-      icon: "event",
-      name: "預約管理",
-      href: "/tutor-panel/booking",
-    },
-    {
-      icon: "auto_stories",
-      name: "學習需求管理",
-      href: "/tutor-panel/learning",
-    },
-    {
-      icon: "equalizer",
-      name: "數據與趨勢",
-      href: "/tutor-panel/statistics",
-    },
-    {
-      icon: "notifications_active",
-      name: "個人化通知",
-      href: "/tutor-panel/notification",
-    },
-    {
-      icon: "person",
-      name: "個人資料管理",
-      href: "/tutor-panel/profile",
-    },
-    {
-      icon: "paid",
-      name: "財務管理",
-      href: "/tutor-panel/finance",
-    },
-  ];
-
-  const user = {
-    avatar:
-      "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    name: "卡斯伯Casper",
-  };
 
   // 返回上一頁
   const navigate = useNavigate();
@@ -64,15 +20,7 @@ export default function TutorManageAddVideo() {
   // ReactQuill 文字編輯器
   const [value, setValue] = useState("");
   const modules = {
-    toolbar: [
-      [{ font: [] }],
-      ["bold", "italic", "underline"],
-      ["link", "image", "video"],
-      [{ list: "ordered" }, { list: "bullet" }],
-      [{ align: [] }],
-      ["blockquote", "code-block"],
-      ["clean"],
-    ],
+    toolbar: [[{ font: [] }], ["bold", "italic", "underline"], ["link", "image", "video"], [{ list: "ordered" }, { list: "bullet" }], [{ align: [] }], ["blockquote", "code-block"], ["clean"]],
   };
 
   // 依路由決定此頁顯示分類
@@ -87,7 +35,7 @@ export default function TutorManageAddVideo() {
       </Helmet>
       {loadingState && <Loader />}
 
-      <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      <TutorPanelMenu>
         <main className="tutor-add-video-wrap container-fluid py-6 py-lg-0">
           <h1 className="fs-4 fs-lg-2">
             {type === "topicSeries" && "新增章節影片"}
@@ -100,22 +48,12 @@ export default function TutorManageAddVideo() {
               <div className="mt-6 mt-lg-8 px-xl-11">
                 <div className="video-upload-wrapper w-100 mt-1">
                   {/* 隱藏的影片上傳 Input */}
-                  <input
-                    type="file"
-                    accept="video/mp4,video/webm,video/ogg"
-                    className="form-control w-100 p-0"
-                    id="video"
-                  />
+                  <input type="file" accept="video/mp4,video/webm,video/ogg" className="form-control w-100 p-0" id="video" />
 
                   {/* 未上傳時的提示 */}
                   {!videoSrc && (
-                    <label
-                      htmlFor="video"
-                      className="form-label video-upload-label w-100 mb-0"
-                    >
-                      <span className="material-symbols-outlined mb-2">
-                        video_file
-                      </span>
+                    <label htmlFor="video" className="form-label video-upload-label w-100 mb-0">
+                      <span className="material-symbols-outlined mb-2">video_file</span>
                       上傳影片
                     </label>
                   )}
@@ -125,34 +63,22 @@ export default function TutorManageAddVideo() {
                     <div className="video-preview">
                       <video src="" controls className="w-100"></video>
                       <button type="button" className="delete-icon">
-                        <span className="material-symbols-outlined">
-                          delete
-                        </span>
+                        <span className="material-symbols-outlined">delete</span>
                       </button>
                     </div>
                   )}
                 </div>
                 <div className="bg-brand-05 rounded-4 mt-8 mt-lg-10 p-6 p-lg-8">
-                  <h2 className="fs-5 fs-lg-4 text-brand-03">
-                    影片上傳注意事項
-                  </h2>
+                  <h2 className="fs-5 fs-lg-4 text-brand-03">影片上傳注意事項</h2>
                   <ul className="py-4">
                     <li>
-                      <p className="fs-6 mt-2">
-                        1. 課程影片應以高畫質（HD）錄製並輸出，建議至少達到 720p
-                        或 1080p 的解析度。
-                      </p>
+                      <p className="fs-6 mt-2">1. 課程影片應以高畫質（HD）錄製並輸出，建議至少達到 720p 或 1080p 的解析度。</p>
                     </li>
                     <li className="mt-4 mt-lg-5">
-                      <p className="fs-6 mt-2">
-                        2. 音訊需為立體聲（左右聲道），並與影片畫面完全同步。
-                      </p>
+                      <p className="fs-6 mt-2">2. 音訊需為立體聲（左右聲道），並與影片畫面完全同步。</p>
                     </li>
                     <li className="mt-4 mt-lg-5">
-                      <p className="fs-6 mt-2">
-                        3.
-                        音訊應保持清晰，避免回音和背景雜音，以確保學生能專注於學習內容。
-                      </p>
+                      <p className="fs-6 mt-2">3. 音訊應保持清晰，避免回音和背景雜音，以確保學生能專注於學習內容。</p>
                     </li>
                   </ul>
                 </div>
@@ -163,35 +89,16 @@ export default function TutorManageAddVideo() {
                 <form className="mt-6 mt-lg-8">
                   <h4 className="fs-7 fw-normal text-gray-01 lh-base">圖片</h4>
                   <div className="image-upload-wrapper mt-1">
-                    <input
-                      type="file"
-                      accept=".jpg,.jpeg,.png"
-                      className="form-control p-0"
-                      id="image"
-                    />
-                    <label
-                      htmlFor="image"
-                      className="form-label image-upload-label mb-0"
-                    >
-                      <span className="material-symbols-outlined mb-2">
-                        imagesmode
-                      </span>
+                    <input type="file" accept=".jpg,.jpeg,.png" className="form-control p-0" id="image" />
+                    <label htmlFor="image" className="form-label image-upload-label mb-0">
+                      <span className="material-symbols-outlined mb-2">imagesmode</span>
                       上傳影片縮圖
                     </label>
 
                     {/* 上傳圖片後的樣子 */}
-                    <button
-                      type="button"
-                      className="img-wrapper border-0 p-0 d-none"
-                    >
-                      <img
-                        src="images/course/course-4.png"
-                        alt="course-thumbnail"
-                        className="w-100 object-fit"
-                      />
-                      <span className="material-symbols-outlined delete-icon">
-                        delete
-                      </span>
+                    <button type="button" className="img-wrapper border-0 p-0 d-none">
+                      <img src="images/course/course-4.png" alt="course-thumbnail" className="w-100 object-fit" />
+                      <span className="material-symbols-outlined delete-icon">delete</span>
                     </button>
                   </div>
 
@@ -199,12 +106,7 @@ export default function TutorManageAddVideo() {
                     <label htmlFor="title" className="form-label">
                       影片標題
                     </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="title"
-                      placeholder="ex. React 進階開發技巧"
-                    />
+                    <input type="text" className="form-control" id="title" placeholder="ex. React 進階開發技巧" />
                   </div>
 
                   {type === "topicSeries" ? (
@@ -216,31 +118,18 @@ export default function TutorManageAddVideo() {
                           <div className="col">
                             <label className="form-label">瀏覽權限</label>
                             <div className="dropdown">
-                              <button
-                                type="button"
-                                className="btn btn-outline-gray-03 border-1 dropdown-toggle d-block w-100 text-start px-4"
-                                data-bs-toggle="dropdown"
-                                aria-expanded="false"
-                              >
+                              <button type="button" className="btn btn-outline-gray-03 border-1 dropdown-toggle d-block w-100 text-start px-4" data-bs-toggle="dropdown" aria-expanded="false">
                                 請選擇瀏覽權限
-                                <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                                  keyboard_arrow_down
-                                </span>
+                                <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
                               </button>
                               <ul className="dropdown-menu w-100 mt-1">
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     公開
                                   </button>
                                 </li>
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     不公開
                                   </button>
                                 </li>
@@ -260,48 +149,31 @@ export default function TutorManageAddVideo() {
                                 aria-expanded="false"
                               >
                                 請選擇類別
-                                <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                                  keyboard_arrow_down
-                                </span>
+                                <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
                               </button>
                               <ul className="dropdown-menu w-100 mt-1">
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     Html
                                   </button>
                                 </li>
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     CSS
                                   </button>
                                 </li>
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     JavaScript
                                   </button>
                                 </li>
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     React
                                   </button>
                                 </li>
                                 <li>
-                                  <button
-                                    type="button"
-                                    className="dropdown-item"
-                                  >
+                                  <button type="button" className="dropdown-item">
                                     Vue
                                   </button>
                                 </li>
@@ -315,12 +187,7 @@ export default function TutorManageAddVideo() {
                         <label htmlFor="searchKeywords" className="form-label">
                           關鍵字 (請用半型逗號隔開)
                         </label>
-                        <input
-                          type="text"
-                          className="form-control"
-                          id="searchKeywords"
-                          placeholder="ex. React, 前端開發, 效能優化, Hooks"
-                        />
+                        <input type="text" className="form-control" id="searchKeywords" placeholder="ex. React, 前端開發, 效能優化, Hooks" />
                       </div>
                     </>
                   )}
@@ -329,12 +196,7 @@ export default function TutorManageAddVideo() {
                     <label htmlFor="content" className="form-label">
                       影片描述
                     </label>
-                    <ReactQuill
-                      value={value}
-                      onChange={setValue}
-                      placeholder="請描述影片教學內容，幫助學習者快速了解。"
-                      modules={modules}
-                    />
+                    <ReactQuill value={value} onChange={setValue} placeholder="請描述影片教學內容，幫助學習者快速了解。" modules={modules} />
                   </div>
                 </form>
               </div>
@@ -343,12 +205,7 @@ export default function TutorManageAddVideo() {
 
           {/*web button wrap */}
           <div className="btn-container text-end mt-auto">
-            <button
-              type="submit"
-              className="btn btn-outline-brand-03 rounded-2 border-3"
-              style={{ padding: "9px 24px" }}
-              onClick={toPrevPage}
-            >
+            <button type="submit" className="btn btn-outline-brand-03 rounded-2 border-3" style={{ padding: "9px 24px" }} onClick={toPrevPage}>
               取消
             </button>
             <button type="submit" className="btn btn-brand-03 rounded-2 ms-4">
@@ -356,7 +213,7 @@ export default function TutorManageAddVideo() {
             </button>
           </div>
         </main>
-      </BackendPanelMenu>
+      </TutorPanelMenu>
     </>
   );
 }

--- a/src/pages/tutor/courses/tutor-chapter-topicSeries.jsx
+++ b/src/pages/tutor/courses/tutor-chapter-topicSeries.jsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate, Link } from "react-router-dom";
 
 import courseApi from "../../../api/courseApi";
 
-import BackendPanelMenu from "../../../components/layout/BackendPanelMenu";
+import TutorPanelMenu from "../../../components/layout/TutorPanelMenu";
 import Loader from "../../../components/common/Loader";
 import Pagination from "../../../components/layout/Pagination";
 
@@ -13,50 +13,6 @@ export default function TutorManageTopicSeriesChapter() {
 
   // loading
   const [loadingState, setLoadingState] = useState(false);
-
-  const menuItems = [
-    {
-      icon: "video_settings",
-      name: "課程影片管理",
-      href: "/tutor-panel/course",
-    },
-    {
-      icon: "event",
-      name: "預約管理",
-      href: "/tutor-panel/booking",
-    },
-    {
-      icon: "auto_stories",
-      name: "學習需求管理",
-      href: "/tutor-panel/learning",
-    },
-    {
-      icon: "equalizer",
-      name: "數據與趨勢",
-      href: "/tutor-panel/statistics",
-    },
-    {
-      icon: "notifications_active",
-      name: "個人化通知",
-      href: "/tutor-panel/notification",
-    },
-    {
-      icon: "person",
-      name: "個人資料管理",
-      href: "/tutor-panel/profile",
-    },
-    {
-      icon: "paid",
-      name: "財務管理",
-      href: "/tutor-panel/finance",
-    },
-  ];
-
-  const user = {
-    avatar:
-      "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    name: "卡斯伯Casper",
-  };
 
   // 返回上一頁
   const navigate = useNavigate();
@@ -89,25 +45,16 @@ export default function TutorManageTopicSeriesChapter() {
       </Helmet>
       {loadingState && <Loader />}
 
-      <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      <TutorPanelMenu>
         <main className="tutor-chapter-topicSeries-wrap container-fluid pb-11">
           <div className="f-between">
             <div className="title f-align-center">
-              <button
-                type="button"
-                className="btn border-0 p-0"
-                onClick={toPrevPage}
-              >
-                <span className="material-symbols-outlined">
-                  arrow_back_ios
-                </span>
+              <button type="button" className="btn border-0 p-0" onClick={toPrevPage}>
+                <span className="material-symbols-outlined">arrow_back_ios</span>
               </button>
               <h1 className="fs-4 fs-lg-2 ms-1">主題式課程影片章節管理</h1>
             </div>
-            <Link
-              to={`/tutor-panel/course/topicSeries/${id}/edit`}
-              className="btn btn btn-brand-03 rounded-2"
-            >
+            <Link to={`/tutor-panel/course/topicSeries/${id}/edit`} className="btn btn btn-brand-03 rounded-2">
               編輯課程資訊
             </Link>
           </div>
@@ -115,16 +62,9 @@ export default function TutorManageTopicSeriesChapter() {
           {/* 篩選與搜尋 */}
           <div className="f-end-center mt-10">
             <div className="dropdown">
-              <button
-                type="button"
-                className="btn btn-outline-gray-03 border-1 dropdown-toggle px-11"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
+              <button type="button" className="btn btn-outline-gray-03 border-1 dropdown-toggle px-11" data-bs-toggle="dropdown" aria-expanded="false">
                 排序方式
-                <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                  keyboard_arrow_down
-                </span>
+                <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
               </button>
               <ul className="dropdown-menu dropdown-menu-end w-100 mt-1">
                 <li>
@@ -140,15 +80,8 @@ export default function TutorManageTopicSeriesChapter() {
               </ul>
             </div>
             <div className="position-relative f-align-center ms-2">
-              <input
-                type="text"
-                className="form-control ps-11"
-                placeholder="搜尋影片"
-              />
-              <span
-                className="material-symbols-outlined text-gray-03 position-absolute ps-4"
-                style={{ width: "20px", height: "20px" }}
-              >
+              <input type="text" className="form-control ps-11" placeholder="搜尋影片" />
+              <span className="material-symbols-outlined text-gray-03 position-absolute ps-4" style={{ width: "20px", height: "20px" }}>
                 search
               </span>
             </div>
@@ -179,22 +112,12 @@ export default function TutorManageTopicSeriesChapter() {
                     <td>{Number(course.viewCount).toLocaleString()}</td>
                     <td>
                       <div>
-                        <Link
-                          to={`/tutor-panel/course/topicSeries/${course.chapterId}/chapter`}
-                          className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0"
-                        >
-                          <span className="material-symbols-outlined me-1">
-                            edit
-                          </span>
+                        <Link to={`/tutor-panel/course/topicSeries/${course.chapterId}/chapter`} className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0">
+                          <span className="material-symbols-outlined me-1">edit</span>
                           編輯
                         </Link>
-                        <button
-                          type="button"
-                          className="btn link-danger border-0 f-align-center p-0 mt-1"
-                        >
-                          <span className="material-symbols-outlined me-1">
-                            delete
-                          </span>
+                        <button type="button" className="btn link-danger border-0 f-align-center p-0 mt-1">
+                          <span className="material-symbols-outlined me-1">delete</span>
                           刪除
                         </button>
                       </div>
@@ -209,7 +132,7 @@ export default function TutorManageTopicSeriesChapter() {
             </div>
           </div>
         </main>
-      </BackendPanelMenu>
+      </TutorPanelMenu>
     </>
   );
 }

--- a/src/pages/tutor/courses/tutor-editCourses-topicSeries .jsx
+++ b/src/pages/tutor/courses/tutor-editCourses-topicSeries .jsx
@@ -6,56 +6,12 @@ import ReactQuill from "react-quill-new";
 
 import courseApi from "../../../api/courseApi";
 
-import BackendPanelMenu from "../../../components/layout/BackendPanelMenu";
+import TutorPanelMenu from "../../../components/layout/TutorPanelMenu";
 import Loader from "../../../components/common/Loader";
 
 export default function TutorManageEditTopicSeries() {
   // loading
   const [loadingState, setLoadingState] = useState(false);
-
-  const menuItems = [
-    {
-      icon: "video_settings",
-      name: "課程影片管理",
-      href: "/tutor-panel/course",
-    },
-    {
-      icon: "event",
-      name: "預約管理",
-      href: "/tutor-panel/booking",
-    },
-    {
-      icon: "auto_stories",
-      name: "學習需求管理",
-      href: "/tutor-panel/learning",
-    },
-    {
-      icon: "equalizer",
-      name: "數據與趨勢",
-      href: "/tutor-panel/statistics",
-    },
-    {
-      icon: "notifications_active",
-      name: "個人化通知",
-      href: "/tutor-panel/notification",
-    },
-    {
-      icon: "person",
-      name: "個人資料管理",
-      href: "/tutor-panel/profile",
-    },
-    {
-      icon: "paid",
-      name: "財務管理",
-      href: "/tutor-panel/finance",
-    },
-  ];
-
-  const user = {
-    avatar:
-      "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    name: "卡斯伯Casper",
-  };
 
   // 返回上一頁
   const navigate = useNavigate();
@@ -66,15 +22,7 @@ export default function TutorManageEditTopicSeries() {
   // ReactQuill 文字編輯器
   const [value, setValue] = useState("");
   const modules = {
-    toolbar: [
-      [{ font: [] }],
-      ["bold", "italic", "underline"],
-      ["link", "image", "video"],
-      [{ list: "ordered" }, { list: "bullet" }],
-      [{ align: [] }],
-      ["blockquote", "code-block"],
-      ["clean"],
-    ],
+    toolbar: [[{ font: [] }], ["bold", "italic", "underline"], ["link", "image", "video"], [{ list: "ordered" }, { list: "bullet" }], [{ align: [] }], ["blockquote", "code-block"], ["clean"]],
   };
 
   const { id } = useParams();
@@ -112,7 +60,7 @@ export default function TutorManageEditTopicSeries() {
       </Helmet>
       {loadingState && <Loader />}
 
-      <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      <TutorPanelMenu>
         <main className="tutor-edit-TopicSeriesCourses-wrap container-fluid">
           <h1 className="fs-4 fs-lg-2">編輯課程影片 - 課程基本資料</h1>
 
@@ -122,38 +70,17 @@ export default function TutorManageEditTopicSeries() {
                 <form className="mt-6 mt-lg-8">
                   <h4 className="fs-7 fw-normal text-gray-01 lh-base">圖片</h4>
                   <div className="image-upload-wrapper mt-1">
-                    {!courseList.thumbnail && (
-                      <input
-                        type="file"
-                        accept=".jpg,.jpeg,.png"
-                        className="form-control p-0"
-                        id="image"
-                      />
-                    )}
-                    <label
-                      htmlFor="image"
-                      className="form-label image-upload-label mb-0"
-                    >
-                      <span className="material-symbols-outlined mb-2">
-                        imagesmode
-                      </span>
+                    {!courseList.thumbnail && <input type="file" accept=".jpg,.jpeg,.png" className="form-control p-0" id="image" />}
+                    <label htmlFor="image" className="form-label image-upload-label mb-0">
+                      <span className="material-symbols-outlined mb-2">imagesmode</span>
                       上傳課程封面圖片
                     </label>
 
                     {/* 上傳圖片後的樣子 */}
                     {courseList.thumbnail && (
-                      <button
-                        type="button"
-                        className="img-wrapper border-0 p-0"
-                      >
-                        <img
-                          src={courseList.thumbnail}
-                          alt="course-thumbnail"
-                          className="w-100 object-fit"
-                        />
-                        <span className="material-symbols-outlined delete-icon">
-                          delete
-                        </span>
+                      <button type="button" className="img-wrapper border-0 p-0">
+                        <img src={courseList.thumbnail} alt="course-thumbnail" className="w-100 object-fit" />
+                        <span className="material-symbols-outlined delete-icon">delete</span>
                       </button>
                     )}
                   </div>
@@ -162,12 +89,7 @@ export default function TutorManageEditTopicSeries() {
                     <label htmlFor="title" className="form-label">
                       系列課程標題
                     </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="title"
-                      placeholder="ex. React 進階開發技巧"
-                    />
+                    <input type="text" className="form-control" id="title" placeholder="ex. React 進階開發技巧" />
                   </div>
 
                   <div className="mt-6 mt-lg-8">
@@ -175,16 +97,9 @@ export default function TutorManageEditTopicSeries() {
                       <div className="col">
                         <label className="form-label">瀏覽權限</label>
                         <div className="dropdown">
-                          <button
-                            type="button"
-                            className="btn btn-outline-gray-03 border-1 dropdown-toggle d-block w-100 text-start px-4"
-                            data-bs-toggle="dropdown"
-                            aria-expanded="false"
-                          >
+                          <button type="button" className="btn btn-outline-gray-03 border-1 dropdown-toggle d-block w-100 text-start px-4" data-bs-toggle="dropdown" aria-expanded="false">
                             {courseList.isPublic ? "公開" : "不公開"}
-                            <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                              keyboard_arrow_down
-                            </span>
+                            <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
                           </button>
                           <ul className="dropdown-menu w-100 mt-1">
                             <li>
@@ -213,9 +128,7 @@ export default function TutorManageEditTopicSeries() {
                             aria-expanded="false"
                           >
                             {courseList.tech_stack}
-                            <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                              keyboard_arrow_down
-                            </span>
+                            <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
                           </button>
                           <ul className="dropdown-menu w-100 mt-1">
                             <li>
@@ -253,24 +166,14 @@ export default function TutorManageEditTopicSeries() {
                     <label htmlFor="searchKeywords" className="form-label">
                       關鍵字 (請用半型逗號隔開)
                     </label>
-                    <input
-                      type="text"
-                      className="form-control"
-                      id="searchKeywords"
-                      placeholder="ex. React, 前端開發, 效能優化, Hooks"
-                    />
+                    <input type="text" className="form-control" id="searchKeywords" placeholder="ex. React, 前端開發, 效能優化, Hooks" />
                   </div>
 
                   <div className="pb-8 mt-6 mt-lg-8">
                     <label htmlFor="content" className="form-label">
                       課程描述
                     </label>
-                    <ReactQuill
-                      value={value}
-                      onChange={setValue}
-                      placeholder="請描述課程目標、課程大綱等內容，幫助學習者快速了解。"
-                      modules={modules}
-                    />
+                    <ReactQuill value={value} onChange={setValue} placeholder="請描述課程目標、課程大綱等內容，幫助學習者快速了解。" modules={modules} />
                   </div>
                 </form>
               </div>
@@ -284,50 +187,29 @@ export default function TutorManageEditTopicSeries() {
                   <li className="f-between-center bg-brand-02 p-4">
                     <p>課程介紹</p>
                     <div className="f-align-center">
-                      <img
-                        src="images/course/course-4.png"
-                        alt="course-image"
-                      />
+                      <img src="images/course/course-4.png" alt="course-image" />
                       <p className="ms-4">React Hooks 深入解析</p>
                     </div>
                     <div className="pe-3 ps-10">
-                      <NavLink
-                        to=""
-                        className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0"
-                      >
-                        <span className="material-symbols-outlined me-1">
-                          edit
-                        </span>
+                      <NavLink to="" className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0">
+                        <span className="material-symbols-outlined me-1">edit</span>
                         編輯
                       </NavLink>
-                      <button
-                        type="button"
-                        className="btn link-danger border-0 f-align-center p-0 mt-1"
-                      >
-                        <span className="material-symbols-outlined me-1">
-                          delete
-                        </span>
+                      <button type="button" className="btn link-danger border-0 f-align-center p-0 mt-1">
+                        <span className="material-symbols-outlined me-1">delete</span>
                         刪除
                       </button>
                     </div>
                   </li>
                   <li className="f-align-center dashed-border p-4 mt-2">
                     <p>第一章</p>
-                    <Link
-                      to="/tutor-panel/course/video/topicSeries/add"
-                      className="btn btn-brand-03 f-align-center rounded-2 border-2 px-3 py-2 ms-auto"
-                    >
-                      <span className="material-symbols-outlined me-1">
-                        add
-                      </span>
+                    <Link to="/tutor-panel/course/video/topicSeries/add" className="btn btn-brand-03 f-align-center rounded-2 border-2 px-3 py-2 ms-auto">
+                      <span className="material-symbols-outlined me-1">add</span>
                       新增章節影片
                     </Link>
                   </li>
                 </ul>
-                <button
-                  type="button"
-                  className="btn btn-outline-brand-03 f-align-center rounded-2 border-2 px-3 py-2 mt-4"
-                >
+                <button type="button" className="btn btn-outline-brand-03 f-align-center rounded-2 border-2 px-3 py-2 mt-4">
                   <span className="material-symbols-outlined me-1">add</span>
                   增加新章節
                 </button>
@@ -337,12 +219,7 @@ export default function TutorManageEditTopicSeries() {
 
           {/*web button wrap */}
           <div className="btn-container text-end mt-auto">
-            <button
-              type="submit"
-              className="btn btn-outline-brand-03 rounded-2 border-3"
-              style={{ padding: "9px 24px" }}
-              onClick={toPrevPage}
-            >
+            <button type="submit" className="btn btn-outline-brand-03 rounded-2 border-3" style={{ padding: "9px 24px" }} onClick={toPrevPage}>
               取消
             </button>
             <button type="submit" className="btn btn-brand-03 rounded-2 ms-4">
@@ -350,7 +227,7 @@ export default function TutorManageEditTopicSeries() {
             </button>
           </div>
         </main>
-      </BackendPanelMenu>
+      </TutorPanelMenu>
     </>
   );
 }

--- a/src/pages/tutor/courses/tutor-manage-courses.jsx
+++ b/src/pages/tutor/courses/tutor-manage-courses.jsx
@@ -6,7 +6,7 @@ import axios from "axios";
 
 import courseApi from "../../../api/courseApi";
 
-import BackendPanelMenu from "../../../components/layout/BackendPanelMenu";
+import TutorPanelMenu from "../../../components/layout/TutorPanelMenu";
 import Loader from "../../../components/common/Loader";
 import Pagination from "../../../components/layout/Pagination";
 
@@ -15,50 +15,6 @@ const { VITE_API_BASE_2 } = import.meta.env;
 export default function TutorManageCourses() {
   // loading
   const [loadingState, setLoadingState] = useState(true);
-
-  const menuItems = [
-    {
-      icon: "video_settings",
-      name: "課程影片管理",
-      href: "/tutor-panel/course",
-    },
-    {
-      icon: "event",
-      name: "預約管理",
-      href: "/tutor-panel/booking",
-    },
-    {
-      icon: "auto_stories",
-      name: "學習需求管理",
-      href: "/tutor-panel/learning",
-    },
-    {
-      icon: "equalizer",
-      name: "數據與趨勢",
-      href: "/tutor-panel/statistics",
-    },
-    {
-      icon: "notifications_active",
-      name: "個人化通知",
-      href: "/tutor-panel/notification",
-    },
-    {
-      icon: "person",
-      name: "個人資料管理",
-      href: "/tutor-panel/profile",
-    },
-    {
-      icon: "paid",
-      name: "財務管理",
-      href: "/tutor-panel/finance",
-    },
-  ];
-
-  const user = {
-    avatar:
-      "https://plus.unsplash.com/premium_photo-1671656349218-5218444643d8?q=80&w=2187&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    name: "卡斯伯Casper",
-  };
 
   const courseCategory = [
     {
@@ -99,9 +55,7 @@ export default function TutorManageCourses() {
     try {
       const tutorResult = await axios.get(`${VITE_API_BASE_2}/api/v1/tutors/1`);
       const topicSeriesCourses = await courseApi.getCourses("topicSeries");
-      const customLearningCourses = await courseApi.getCourses(
-        "customLearning"
-      );
+      const customLearningCourses = await courseApi.getCourses("customLearning");
       const freeTipShortsCourses = await courseApi.getCourses("freeTipShorts");
 
       setCourses((prevCourses) => ({
@@ -129,39 +83,31 @@ export default function TutorManageCourses() {
       </Helmet>
       {loadingState && <Loader />}
 
-      <BackendPanelMenu menuItems={menuItems} type="tutor" user={user}>
+      <TutorPanelMenu>
         <main className="tutor-manage-course-list-wrap container-fluid">
           <div className="f-between">
             <div className="title">
               <h1 className="fs-4 fs-lg-2">課程影片管理</h1>
             </div>
             <div className="dropdown">
-              <button
-                className="btn btn btn-brand-03 rounded-2 dropdown-toggle"
-                type="button"
-                id="dropdownMenuButton1"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
+              <button className="btn btn btn-brand-03 rounded-2 dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
                 建立新的影片
               </button>
-              <ul
-                className="dropdown-menu dropdown-menu-end mt-2"
-                aria-labelledby="dropdownMenuButton1"
-              >
+              <ul className="dropdown-menu dropdown-menu-end mt-2" aria-labelledby="dropdownMenuButton1">
                 <li>
-                  <Link
-                    to="/tutor-panel/course/topicSeries/add"
-                    className="dropdown-item"
-                  >
+                  <Link to="/tutor-panel/course/topicSeries/add" className="dropdown-item">
                     建立主題式課程影片
                   </Link>
                 </li>
                 <li>
-                  <Link to="/tutor-panel/course/video/customLearning/add" className="dropdown-item">建立客製化需求影片</Link>
+                  <Link to="/tutor-panel/course/video/customLearning/add" className="dropdown-item">
+                    建立客製化需求影片
+                  </Link>
                 </li>
                 <li>
-                  <Link to="/tutor-panel/course/video/freeTipShorts/add" className="dropdown-item">建立實用技術短影片</Link>
+                  <Link to="/tutor-panel/course/video/freeTipShorts/add" className="dropdown-item">
+                    建立實用技術短影片
+                  </Link>
                 </li>
               </ul>
             </div>
@@ -170,16 +116,9 @@ export default function TutorManageCourses() {
           {/* 篩選與搜尋 */}
           <div className="f-end-center mt-10">
             <div className="dropdown">
-              <button
-                type="button"
-                className="btn btn-outline-gray-03 border-1 dropdown-toggle px-11"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
+              <button type="button" className="btn btn-outline-gray-03 border-1 dropdown-toggle px-11" data-bs-toggle="dropdown" aria-expanded="false">
                 排序方式
-                <span className="material-symbols-outlined position-absolute end-0 pe-3">
-                  keyboard_arrow_down
-                </span>
+                <span className="material-symbols-outlined position-absolute end-0 pe-3">keyboard_arrow_down</span>
               </button>
               <ul className="dropdown-menu dropdown-menu-end mt-1">
                 <li>
@@ -195,32 +134,19 @@ export default function TutorManageCourses() {
               </ul>
             </div>
             <div className="position-relative f-align-center ms-2">
-              <input
-                type="text"
-                className="form-control ps-11"
-                placeholder="搜尋課程"
-              />
-              <span
-                className="material-symbols-outlined text-gray-03 position-absolute ps-4"
-                style={{ width: "20px", height: "20px" }}
-              >
+              <input type="text" className="form-control ps-11" placeholder="搜尋課程" />
+              <span className="material-symbols-outlined text-gray-03 position-absolute ps-4" style={{ width: "20px", height: "20px" }}>
                 search
               </span>
             </div>
           </div>
 
           {/* 影片列表 */}
-          <ul
-            className="nav nav-tabs border-bottom border-gray-03 mt-4"
-            id="courseCategoryTab"
-            role="tablist"
-          >
+          <ul className="nav nav-tabs border-bottom border-gray-03 mt-4" id="courseCategoryTab" role="tablist">
             {courseCategory.map((item, index) => (
               <li className="nav-item" role="presentation" key={index}>
                 <button
-                  className={`nav-link fs-7 fs-lg-6 p-2 py-lg-3 px-lg-4 ${
-                    index === activeTab && "active"
-                  }`}
+                  className={`nav-link fs-7 fs-lg-6 p-2 py-lg-3 px-lg-4 ${index === activeTab && "active"}`}
                   id={`${item.category}-tab`}
                   data-bs-toggle="tab"
                   data-bs-target={`#${item.category}`}
@@ -237,25 +163,13 @@ export default function TutorManageCourses() {
           </ul>
           <div className="tab-content" id="courseCategoryTab">
             {courseCategory.map((item, index) => (
-              <div
-                className={`tab-pane ${
-                  index === activeTab ? "active show" : "fade"
-                }`}
-                id={item.category}
-                role="tabpanel"
-                aria-labelledby={`${item.category}-tab`}
-                key={index}
-              >
+              <div className={`tab-pane ${index === activeTab ? "active show" : "fade"}`} id={item.category} role="tabpanel" aria-labelledby={`${item.category}-tab`} key={index}>
                 <div className="mt-6 mt-lg-8">
                   <table className="table">
                     <thead>
                       <tr>
                         <th></th>
-                        <th>
-                          {item.category === "topicSeries"
-                            ? "課程名稱"
-                            : "影片名稱"}
-                        </th>
+                        <th>{item.category === "topicSeries" ? "課程名稱" : "影片名稱"}</th>
                         <th>類別</th>
                         <th>瀏覽權限</th>
                         <th>上傳日期</th>
@@ -275,28 +189,16 @@ export default function TutorManageCourses() {
                             <td>{course.tag}</td>
                             <td>{course.isPublic ? "公開" : "未公開"}</td>
                             <td>2024年12月1日</td>
-                            <td>
-                              {Number(course.view_count).toLocaleString()}
-                            </td>
+                            <td>{Number(course.view_count).toLocaleString()}</td>
                             <td>{course.rating}</td>
                             <td>
                               <div>
-                                <NavLink
-                                  to={`/tutor-panel/course/topicSeries/${course.id}/chapter`}
-                                  className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0"
-                                >
-                                  <span className="material-symbols-outlined me-1">
-                                    dataset
-                                  </span>
+                                <NavLink to={`/tutor-panel/course/topicSeries/${course.id}/chapter`} className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0">
+                                  <span className="material-symbols-outlined me-1">dataset</span>
                                   詳細
                                 </NavLink>
-                                <button
-                                  type="button"
-                                  className="btn link-danger border-0 f-align-center p-0 mt-1"
-                                >
-                                  <span className="material-symbols-outlined me-1">
-                                    delete
-                                  </span>
+                                <button type="button" className="btn link-danger border-0 f-align-center p-0 mt-1">
+                                  <span className="material-symbols-outlined me-1">delete</span>
                                   刪除
                                 </button>
                               </div>
@@ -315,28 +217,16 @@ export default function TutorManageCourses() {
                             <td>{course.tag}</td>
                             <td>{course.isPublic ? "公開" : "未公開"}</td>
                             <td>2024年12月1日</td>
-                            <td>
-                              {Number(course.view_count).toLocaleString()}
-                            </td>
+                            <td>{Number(course.view_count).toLocaleString()}</td>
                             <td>{course.rating}</td>
                             <td>
                               <div>
-                                <NavLink
-                                  to={`/tutor-panel/course/${course.id}/edit`}
-                                  className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0"
-                                >
-                                  <span className="material-symbols-outlined me-1">
-                                    edit
-                                  </span>
+                                <NavLink to={`/tutor-panel/course/${course.id}/edit`} className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0">
+                                  <span className="material-symbols-outlined me-1">edit</span>
                                   編輯
                                 </NavLink>
-                                <button
-                                  type="button"
-                                  className="btn link-danger border-0 f-align-center p-0 mt-1"
-                                >
-                                  <span className="material-symbols-outlined me-1">
-                                    delete
-                                  </span>
+                                <button type="button" className="btn link-danger border-0 f-align-center p-0 mt-1">
+                                  <span className="material-symbols-outlined me-1">delete</span>
                                   刪除
                                 </button>
                               </div>
@@ -355,28 +245,16 @@ export default function TutorManageCourses() {
                             <td>{course.tag}</td>
                             <td>{course.isPublic ? "公開" : "未公開"}</td>
                             <td>2024年12月1日</td>
-                            <td>
-                              {Number(course.view_count).toLocaleString()}
-                            </td>
+                            <td>{Number(course.view_count).toLocaleString()}</td>
                             <td>{course.rating}</td>
                             <td>
                               <div>
-                                <NavLink
-                                  to={`/tutor-panel/course/${course.id}/edit`}
-                                  className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0"
-                                >
-                                  <span className="material-symbols-outlined me-1">
-                                    edit
-                                  </span>
+                                <NavLink to={`/tutor-panel/course/${course.id}/edit`} className="btn link-brand-03 border-0 d-inline-flex f-align-center p-0">
+                                  <span className="material-symbols-outlined me-1">edit</span>
                                   編輯
                                 </NavLink>
-                                <button
-                                  type="button"
-                                  className="btn link-danger border-0 f-align-center p-0 mt-1"
-                                >
-                                  <span className="material-symbols-outlined me-1">
-                                    delete
-                                  </span>
+                                <button type="button" className="btn link-danger border-0 f-align-center p-0 mt-1">
+                                  <span className="material-symbols-outlined me-1">delete</span>
                                   刪除
                                 </button>
                               </div>
@@ -395,7 +273,7 @@ export default function TutorManageCourses() {
         <div className="position-absolute end-0 bottom-0 pe-6 pb-6">
           <Pagination />
         </div>
-      </BackendPanelMenu>
+      </TutorPanelMenu>
     </>
   );
 }

--- a/src/router/routes.jsx
+++ b/src/router/routes.jsx
@@ -24,7 +24,7 @@ import TutorInfo from "../pages/user/tutor/tutor-info";
 
 import HelpCenter from "../pages/user/help-center";
 
-import TutorManageBooking from "../pages/tutor/tutor-manage-bookings";
+import TutorManageBooking from "../pages/tutor/bookings/tutor-manage-bookings";
 
 import TutorManageCourses from "../pages/tutor/courses/tutor-manage-courses";
 import TutorManageAddTopicSeries from "../pages/tutor/courses/tutor-addCourses-topicSeries";
@@ -33,8 +33,6 @@ import TutorManageTopicSeriesChapter from "../pages/tutor/courses/tutor-chapter-
 import TutorManageAddVideo from "../pages/tutor/courses/tutor-addVideo";
 
 import NotFound from "../pages/NotFound";
-
-
 
 export const routes = [
   { path: "/", element: <Home /> },
@@ -66,10 +64,10 @@ export const routes = [
   { path: "/tutor-panel/booking", element: <TutorManageBooking /> },
 
   { path: "/tutor-panel/course", element: <TutorManageCourses /> },
-  { path: "/tutor-panel/course/topicSeries/add", element: <TutorManageAddTopicSeries/> },
+  { path: "/tutor-panel/course/topicSeries/add", element: <TutorManageAddTopicSeries /> },
   { path: "/tutor-panel/course/topicSeries/:id/edit", element: <TutorManageEditTopicSeries /> },
-  { path: "/tutor-panel/course/topicSeries/:id/chapter", element: <TutorManageTopicSeriesChapter/> },
-  { path: "/tutor-panel/course/video/:type/add", element: <TutorManageAddVideo/> },
+  { path: "/tutor-panel/course/topicSeries/:id/chapter", element: <TutorManageTopicSeriesChapter /> },
+  { path: "/tutor-panel/course/video/:type/add", element: <TutorManageAddVideo /> },
 
   { path: "*", element: <NotFound /> },
 ];


### PR DESCRIPTION
修改了以下的內容
1. 後台Menu手機桌面共用一個children
2. 基於BackendPanelMenu，新增了對應的Tutor和Student的menu layout，並且把原有套用了BackendPanelMenu的頁面改為使用TutorPanelMenu
3. Menu的Icon和文字padding修改到8px
4. 新增儀表板的menu item