### PR TITLE
fix: 修正批改問題 #3 前台預約問題(金流返回問題除外)

### DIFF
--- a/src/assets/scss/pages/_tutor-booking.scss
+++ b/src/assets/scss/pages/_tutor-booking.scss
@@ -51,12 +51,18 @@
 
   .prev,
   .next {
+    transition: "background-color" 1s ease;
     background-color: $brand-02;
     color: $brand-01;
     &.disabled {
       background-color: rgb(236, 235, 235);
       color: rgb(216, 216, 216);
     }
+    &:hover {
+      transition: "background-color" 1s ease;
+      background-color: #ebe0ff;
+    }
+
     @include lg-pc {
       font-size: 18px;
     }
@@ -179,6 +185,15 @@
   .modal-dialog {
     @media (min-width: 576px) {
       max-width: 80vw;
+    }
+  }
+
+  .next-btn {
+    transition: "background-color" 1s ease;
+
+    &:hover {
+      transition: "background-color" 1s ease;
+      background-color: #ebe0ff;
     }
   }
 

--- a/src/components/tutor-panel/booking/available-time/BusinessHour.jsx
+++ b/src/components/tutor-panel/booking/available-time/BusinessHour.jsx
@@ -169,11 +169,11 @@ export default function BusinessHour({ type, day, defaultValue, revalidateAvaila
               {/* Accordion Header */}
               <h2 className="accordion-header">
                 <button
-                  className="accordion-button collapsed ps-2"
+                  className={`accordion-button ${type === "newSpecific" ? "" : "collapsed"} ps-2`}
                   type="button"
                   data-bs-toggle="collapse"
                   data-bs-target={`#collapse${day}-${type}`}
-                  aria-expanded={"false"}
+                  aria-expanded={type === "newSpecific" ? "true" : "false"}
                   aria-controls={`collapse${day}-${type}`}
                   style={{ backgroundColor: "transparent", boxShadow: "none" }}
                 >
@@ -188,7 +188,7 @@ export default function BusinessHour({ type, day, defaultValue, revalidateAvaila
               </h2>
 
               {/* Accordion Body */}
-              <div id={`collapse${day}-${type}`} className={`accordion-collapse collapse`} data-bs-parent={`#accordion${day}-${type}`}>
+              <div id={`collapse${day}-${type}`} className={`accordion-collapse collapse ${type === "newSpecific" ? "show" : ""}`} data-bs-parent={`#accordion${day}-${type}`}>
                 <div className="accordion-body pt-0">
                   <Controller
                     name={`is_open`}

--- a/src/pages/user/tutor/tutor-booking-payment-result.jsx
+++ b/src/pages/user/tutor/tutor-booking-payment-result.jsx
@@ -11,11 +11,7 @@ import { serviceTypeMap } from "@/utils/schema/booking-schema";
 import { formatDate, formatHour } from "@/utils/timeFormatted-utils";
 
 export default function BookingPaymentResult() {
-  // loading
   const [loadingState, setLoadingState] = useState(false);
-
-  // eslint-disable-next-line no-unused-vars
-  const [payResult, setPayResult] = useState([]);
   const [isPaid, setIsPaid] = useState(false);
   const [isPending, setIsPending] = useState(true);
 
@@ -23,12 +19,10 @@ export default function BookingPaymentResult() {
     setLoadingState(true);
     try {
       const response = await orderApi.checkPayResult(transactionId);
-      setPayResult(response);
       const transaction = response;
 
       if (transaction.status === "completed" || transaction.status === "paid") {
         setIsPaid(true);
-        // updateOrderStatus(subscriptionId);
       } else {
         Swal.fire({
           icon: "warning",
@@ -47,28 +41,6 @@ export default function BookingPaymentResult() {
       setLoadingState(false);
     }
   };
-
-  // 更新訂單狀態
-  //   const updateOrderStatus = async (subscriptionId) => {
-  //     setLoadingState(true);
-  //     try {
-  //       await subscriptionApi.updateSubscription(subscriptionId, {
-  //         status: "active",
-  //       }),
-  //         Swal.fire({
-  //           title: "付款成功",
-  //           icon: "success",
-  //         });
-  //     } catch (error) {
-  //       Swal.fire({
-  //         icon: "error",
-  //         title: "訂單狀態更新失敗",
-  //         text: error.response?.data?.message || "發生未知錯誤",
-  //       });
-  //     } finally {
-  //       setLoadingState(false);
-  //     }
-  //   };
 
   // 取用付款頁存下來的資料
   const [bookingSuccessResult, setBookingSuccessResult] = useState({

--- a/src/pages/user/tutor/tutor-booking-payment.jsx
+++ b/src/pages/user/tutor/tutor-booking-payment.jsx
@@ -36,8 +36,8 @@ export default function TutorBookingPayment() {
   // 建立Dispatch 來修改 RTK的State
   const dispatch = useDispatch();
   const { isAuth, userData } = useSelector((state) => state.auth);
-  const bookingStep1FormData = useSelector((state) => state.booking);
-  const { tutor_id, tutor_name, booking_date, timeslots, service_type, price } = bookingStep1FormData;
+  const bookingFormData = useSelector((state) => state.booking);
+  const { tutor_id, tutor_name, booking_date, timeslots, service_type, price } = bookingFormData;
 
   useEffect(() => {
     if (!isAuth) {

--- a/src/pages/user/tutor/tutor-booking.jsx
+++ b/src/pages/user/tutor/tutor-booking.jsx
@@ -926,7 +926,7 @@ export default function TutorBooking() {
             <div className="modal-footer border-top-0 p-0">
               <div className="d-flex flex-column align-items-end">
                 {modalError && <p className="text-danger mb-3">{modalError}</p>}
-                <button type="button" className="btn btn-secondary fs-7 fs-md-6 py-2" onClick={toNextModalStep}>
+                <button type="button" className="btn btn-secondary next-btn fs-7 fs-md-6 py-2" onClick={toNextModalStep}>
                   下一步
                 </button>
               </div>

--- a/src/pages/user/tutor/tutor-list.jsx
+++ b/src/pages/user/tutor/tutor-list.jsx
@@ -11,10 +11,12 @@ import MainTitle from "@/components/MainTitle";
 import TutorsCard from "@/components/tutor/TutorsCard";
 import Pagination from "@/components/layout/Pagination";
 import Loader from "@/components/common/Loader";
+import TutorCardLoadingSkeleton from "@/components/tutor/TutorCardLoadingSkeleton";
 
 export default function TutorList() {
   // loading
   const [loadingState, setLoadingState] = useState(true);
+  const [loadingTutorState, setLoadingTutorState] = useState(false);
 
   const userImages = [
     "images/user/user-1.png",
@@ -52,14 +54,10 @@ export default function TutorList() {
   const [pageData, setPageData] = useState({});
   const getTutorsData = useCallback(
     async (currentPage = 1) => {
-      setLoadingState(true);
+      setLoadingTutorState(true);
       try {
-        const tutorResult = await tutorApi.getAllTutor(
-          currentPage,
-          sortBy,
-          order,
-          search
-        );
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        const tutorResult = await tutorApi.getAllTutor(currentPage, sortBy, order, search);
         setTutorsList(tutorResult.tutors);
         setPageData(tutorResult.pagination);
       } catch (error) {
@@ -69,7 +67,7 @@ export default function TutorList() {
           text: error.response?.data?.message || "發生錯誤，請稍後再試",
         });
       } finally {
-        setLoadingState(false);
+        setLoadingTutorState(false);
       }
     },
     [search, sortBy, order]
@@ -90,6 +88,14 @@ export default function TutorList() {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoadingState(false);
+    }, 1000);
+
+    return () => clearTimeout(timer); // cleanup
+  }, []);
+
   // 初始化 - AOS
   useEffect(() => {
     AOS.init();
@@ -105,6 +111,7 @@ export default function TutorList() {
       <Helmet>
         <title>Coding∞bit ｜ 可預約講師一覽</title>
       </Helmet>
+
       {loadingState && <Loader />}
 
       <main className="tutor-list">
@@ -114,37 +121,21 @@ export default function TutorList() {
             <div className="d-flex justify-content-md-around align-items-md-center">
               <div>
                 <div className="question-text-wrapper">
-                  <h2 className="fs-1 mb-2 question-text text-brand-03">
-                    {titleText}
-                  </h2>
+                  <h2 className="fs-1 mb-2 question-text text-brand-03">{titleText}</h2>
                 </div>
                 <h2 className="fs-md-1 fs-2 mb-12">找專業講師來場一對一課程</h2>
-                <a
-                  className="w-50 btn btn-brand-03 cta-btn f-center slide-down-hover mb-5"
-                  onClick={handleScroll}
-                >
+                <a className="w-50 btn btn-brand-03 cta-btn f-center slide-down-hover mb-5" onClick={handleScroll}>
                   我要找講師
-                  <span className="material-symbols-outlined">
-                    keyboard_arrow_down
-                  </span>
+                  <span className="material-symbols-outlined">keyboard_arrow_down</span>
                 </a>
                 <div className="d-flex align-items-center">
                   {userImages.map((src, index) => (
-                    <img
-                      key={index}
-                      src={src}
-                      alt="tutor"
-                      className="object-cover-fit profile"
-                    />
+                    <img key={index} src={src} alt="tutor" className="object-cover-fit profile" />
                   ))}
                   <p className="profile">100+</p>
                 </div>
               </div>
-              <img
-                src="images/deco/star3D.png"
-                className="star-deco"
-                alt="star-deco"
-              />
+              <img src="images/deco/star3D.png" className="star-deco" alt="star-deco" />
             </div>
           </div>
         </section>
@@ -154,53 +145,22 @@ export default function TutorList() {
           <div className="container">
             {/* title */}
             <div className="f-center flex-column">
-              <MainTitle
-                longTitle={false}
-                beforeTitle="什麼是一對一教學 & 程式碼檢視服務"
-                afterTitle=""
-              />
-              <p className="mt-5 mb-11 description fs-md-5 fs-6">
-                只要您訂閱成為基本會員，即可購買專業講師一對一課程或是程式碼檢視服務。
-              </p>
+              <MainTitle longTitle={false} beforeTitle="什麼是一對一教學 & 程式碼檢視服務" afterTitle="" />
+              <p className="mt-5 mb-11 description fs-md-5 fs-6">只要您訂閱成為基本會員，即可購買專業講師一對一課程或是程式碼檢視服務。</p>
             </div>
             <div className="row justify-content-around">
               <div className="col-lg-6 col-md-8">
                 {/* description */}
                 <div>
-                  <div
-                    className="mb-8 f-center"
-                    data-aos="fade-right"
-                    data-aos-easing="linear"
-                    data-aos-duration="800"
-                    data-aos-offset="200"
-                  >
-                    <p className="tag bg-brand-03 text-white fs-md-5 fs-7 text-nowrap me-3">
-                      一對一課程
-                    </p>
-                    <span className="material-symbols-outlined me-3">
-                      chevron_right
-                    </span>
-                    <p className="fs-md-5 fs-7">
-                      不怕問題被淹沒在人海之中，只要預約，就可以在線上接受指定講師的單獨教學。
-                    </p>
+                  <div className="mb-8 f-center" data-aos="fade-right" data-aos-easing="linear" data-aos-duration="800" data-aos-offset="200">
+                    <p className="tag bg-brand-03 text-white fs-md-5 fs-7 text-nowrap me-3">一對一課程</p>
+                    <span className="material-symbols-outlined me-3">chevron_right</span>
+                    <p className="fs-md-5 fs-7">不怕問題被淹沒在人海之中，只要預約，就可以在線上接受指定講師的單獨教學。</p>
                   </div>
-                  <div
-                    className="mb-8 f-center"
-                    data-aos="fade-right"
-                    data-aos-easing="linear"
-                    data-aos-duration="800"
-                    data-aos-delay="300"
-                    data-aos-offset="200"
-                  >
-                    <p className="tag bg-brand-03 text-white fs-md-5 fs-7 text-nowrap me-3">
-                      程式碼檢視
-                    </p>
-                    <span className="material-symbols-outlined me-3">
-                      chevron_right
-                    </span>
-                    <p className="fs-md-5 fs-7">
-                      預約時提交想接受指導的程式碼，講師將會於預約時間回覆指導，再也不怕code沒有人批改。
-                    </p>
+                  <div className="mb-8 f-center" data-aos="fade-right" data-aos-easing="linear" data-aos-duration="800" data-aos-delay="300" data-aos-offset="200">
+                    <p className="tag bg-brand-03 text-white fs-md-5 fs-7 text-nowrap me-3">程式碼檢視</p>
+                    <span className="material-symbols-outlined me-3">chevron_right</span>
+                    <p className="fs-md-5 fs-7">預約時提交想接受指導的程式碼，講師將會於預約時間回覆指導，再也不怕code沒有人批改。</p>
                   </div>
                 </div>
 
@@ -217,11 +177,7 @@ export default function TutorList() {
               </div>
               {/* image */}
               <div className="col-4">
-                <img
-                  src="images/deco/Illustration-9.png"
-                  alt="illustration"
-                  className="deco-img"
-                />
+                <img src="images/deco/Illustration-9.png" alt="illustration" className="deco-img" />
               </div>
             </div>
           </div>
@@ -230,48 +186,23 @@ export default function TutorList() {
         {/* Tutor Cards */}
         <section ref={tutorListRef} className="wrap">
           <div className="container">
-            <MainTitle
-              longTitle={false}
-              beforeTitle="尋找喜歡的講師"
-              afterTitle=""
-            />
+            <MainTitle longTitle={false} beforeTitle="尋找喜歡的講師" afterTitle="" />
             <div className="mt-8">
               <div className="control-group">
                 <div className="position-relative f-align-center d-flex me-2 search-tutor">
-                  <input
-                    type="search"
-                    className="form-control nav-search-desktop border border-brand-03 border-3"
-                    placeholder="搜尋講師"
-                    onKeyDown={handleSearch}
-                  />
-                  <span
-                    className="material-symbols-outlined text-gray-03 position-absolute ps-4"
-                    style={{ width: "20px", height: "20px" }}
-                  >
+                  <input type="search" className="form-control nav-search-desktop border border-brand-03 border-3" placeholder="搜尋講師" onKeyDown={handleSearch} />
+                  <span className="material-symbols-outlined text-gray-03 position-absolute ps-4" style={{ width: "20px", height: "20px" }}>
                     search
                   </span>
                 </div>
 
                 <div className="sort">
-                  <button
-                    type="button"
-                    className="btn btn-outline-brand-03 dropdown-toggle"
-                    data-bs-toggle="dropdown"
-                    aria-expanded="false"
-                  >
+                  <button type="button" className="btn btn-outline-brand-03 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
                     {sortBy === "rating" && "排序方式(最高評價)"}
-                    {sortBy === "hourly_rate" &&
-                      order === "ASC" &&
-                      "排序方式(預約價格最低)"}
-                    {sortBy === "hourly_rate" &&
-                      order !== "ASC" &&
-                      "排序方式(預約價格最高)"}
-                    {sortBy === "created_at" &&
-                      order !== "ASC" &&
-                      "成為老師時間(最新到最舊)"}
-                    {sortBy === "created_at" &&
-                      order === "ASC" &&
-                      "成為老師時間(最舊到最新)"}
+                    {sortBy === "hourly_rate" && order === "ASC" && "排序方式(預約價格最低)"}
+                    {sortBy === "hourly_rate" && order !== "ASC" && "排序方式(預約價格最高)"}
+                    {sortBy === "created_at" && order !== "ASC" && "成為老師時間(最新到最舊)"}
+                    {sortBy === "created_at" && order === "ASC" && "成為老師時間(最舊到最新)"}
                   </button>
 
                   <ul className="dropdown-menu dropdown-menu-end">
@@ -340,20 +271,27 @@ export default function TutorList() {
               </div>
             </div>
             <div className="my-8">
-              {tutorsList.length > 0 ? (
+              {loadingTutorState ? (
+                <div className="row row-cols-lg-3 row-cols-md-2 row-cols-1 g-4">
+                  {Array.from({ length: 9 }, (_, i) => (
+                    <li className="tutor-card col" key={i}>
+                      <TutorCardLoadingSkeleton />
+                    </li>
+                  ))}
+                </div>
+              ) : tutorsList.length > 0 ? (
                 <TutorsCard tutorList={tutorsList} cardsNum={3} />
               ) : (
                 <div className="d-flex justify-content-md-around align-items-md-center">
-                  <h2 className="fw-medium text-brand-03 py-6 py-lg-11">
-                    此類別目前沒有資料，請選擇其他類別
-                  </h2>
+                  <h2 className="fw-medium text-brand-03 py-6 py-lg-11">此類別目前沒有資料，請選擇其他類別</h2>
                 </div>
               )}
             </div>
-
-            <nav aria-label="navigation">
-              <Pagination pageData={pageData} getData={getTutorsData} />
-            </nav>
+            {tutorsList.length > 0 && (
+              <nav aria-label="navigation">
+                <Pagination pageData={pageData} getData={getTutorsData} />
+              </nav>
+            )}
           </div>
         </section>
       </main>


### PR DESCRIPTION
修正批改問題 #3 預約相關問題金流返回問題除外)：

- tutor-booking-payment-result.jsx 第 18 行 payResult **看起來沒用到，可以再思考看看是否需要這個狀態
- tutor-booking-payment.jsx 第 39 行，bookingStep1FormData **也許可以命名為 formData 就好
- tutor-list 下方講師區塊切換排序或搜尋時，由於速度很快，loading 幾乎只有閃一下而已，可以考慮不用 Loading 或是加長 Loading 顯示的時間
- 學生在預約講師選擇日期時，左右調整週數的箭頭可以加上 hover，下一步按鈕的 hover 樣式不太明顯
- 老師後台「預約管理」中的設定特定日期可預約時間這個操作看起來不太明確，選完日期後不知道有什麼改動，也許可以再調整看看 (調整至會自動打開accordion）
