### PR TITLE
fix: 客製化需求管理頁面 userData 初始化錯誤

### DIFF
--- a/src/pages/student/custom-request/student-manage-custom-requests.jsx
+++ b/src/pages/student/custom-request/student-manage-custom-requests.jsx
@@ -15,6 +15,10 @@ import Loader from "@/components/common/Loader";
 import { formatDateToTaiwanStyle } from "@/utils/timeFormatted-utils";
 
 export default function StudentManageCustomRequests() {
+  // auth
+  const { isAuth } = useSelector((state) => state.auth);
+  const { userData } = useSelector((state) => state.auth);
+
   // loading
   const [loadingState, setLoadingState] = useState(true);
 
@@ -23,6 +27,8 @@ export default function StudentManageCustomRequests() {
   const [pageData, setPageData] = useState({});
   const getData = useCallback(
     async (page = 1) => {
+      if (!userData?.id) return;
+
       setLoadingState(true);
       try {
         const result = await customRequestsApi.getUserCustomRequests(
@@ -41,7 +47,7 @@ export default function StudentManageCustomRequests() {
         setLoadingState(false);
       }
     },
-    [userData.id]
+    [userData?.id]
   );
 
   // 更新需求
@@ -111,9 +117,6 @@ export default function StudentManageCustomRequests() {
     myModal.current = new bootstrap.Modal(cardModalRef.current);
   }, []);
 
-  // auth
-  const { isAuth } = useSelector((state) => state.auth);
-  const { userData } = useSelector((state) => state.auth);
   // 初始化 - 取得資料
   useEffect(() => {
     if (isAuth) {


### PR DESCRIPTION
  ## Summary
  - 修正學生管理客製化需求頁面的 userData 初始化錯誤
  - 將 `userData` 宣告移到元件頂部，避免 Temporal Dead Zone (TDZ) 錯誤
  - 在 `getData` 函數中加入 `userData?.id` 檢查，防止 API 呼叫時傳入 undefined

  ## Changes
  - 將 `useSelector` 取得的 `isAuth` 和 `userData` 移到元件最頂部宣告
  - 在 `getData` 函數開頭加入 `if (!userData?.id) return;` 檢查
  - 將依賴陣列從 `[userData.id]` 改為 `[userData?.id]` 使用可選鏈結