### PR TITLE
fix: 修正學生收藏頁面導師連結使用錯誤的 ID

### DIFF
--- a/src/pages/student/student-favorites.jsx
+++ b/src/pages/student/student-favorites.jsx
@@ -270,7 +270,7 @@ function StudentFavorites() {
                         </div>
 
                         <NavLink
-                          to={`/tutor/${tutor.Tutor.User.id}`}
+                          to={`/tutor/${tutor.Tutor.id}`}
                           className="btn btn-brand-03 w-100 slide-right-hover"
                         >
                           <p className="f-center me-1">


### PR DESCRIPTION
  ## Summary
  修正學生收藏頁面中「收藏導師」分頁的導師卡片連結錯誤。

  **問題：**
  - 收藏導師頁面的「前往導師頁」按鈕使用了錯誤的 ID
  - 原本使用 `tutor.Tutor.User.id`（用戶 ID），導致無法正確導向導師預約頁面

  **修正：**
  - 將連結改為使用 `tutor.Tutor.id`（導師 ID）
  - 與專案中其他導師卡片組件（TutorCard.jsx）保持一致

  **修改檔案：**
  - `src/pages/student/student-favorites.jsx:273`